### PR TITLE
Updating `read_bop()` function to download and read ABS data from a local file

### DIFF
--- a/R/read_bop.R
+++ b/R/read_bop.R
@@ -13,20 +13,29 @@
 #' @importFrom dplyr .data
 
 read_bop <- function(path = tempdir()) {
+  readabs::download_abs_data_cube(
+      "balance-payments-and-international-investment-position-australia",
+      "21.xls",
+      path
+      )
+
   credits <- suppressMessages(
-    readabs::read_abs("5302.0", 21,
-      path = path,
-      check_local = FALSE,
-      show_progress_bars = FALSE
+    readabs::read_abs_local(path = path,
+      filenames = list.files(path)[grepl("21.xls", list.files(path))]
     )
   ) %>%
     dplyr::mutate(series = paste("Exports", .data$series, sep = " ; "))
+  unlink(file.path(path, list.files(path)[grepl("21.xls", list.files(path))]))
+
+  readabs::download_abs_data_cube(
+      "balance-payments-and-international-investment-position-australia",
+      "22.xls",
+      path
+      )
 
   debits <- suppressMessages(
-    readabs::read_abs("5302.0", 22,
-      path = path,
-      check_local = FALSE,
-      show_progress_bars = FALSE
+    readabs::read_abs_local(path = path,
+      filenames = list.files(path)[grepl("22.xls", list.files(path))]
     )
   ) %>%
     dplyr::mutate(series = paste("Imports", .data$series, sep = " ; "))


### PR DESCRIPTION
The Balance of Payments and International Investment Position ABS Series is no longer using catalogue number 5302.0. In order for future releases to remain included in this dataset, I have changed the `read_bop()` function to download the time series spreadsheets from the ABS and read them in. 