### PR TITLE
New chart to show cumulative yearly growth in exports to fix issue #29

### DIFF
--- a/R/page_bop.R
+++ b/R/page_bop.R
@@ -14,9 +14,7 @@ page_bop <- function(...) {
     br(),
     djpr_plot_ui("goods_export_import_line"),
     br(),
-    djpr_plot_ui("vic_total_bop_cumul_line",
-      interactive = FALSE
-    ),
+    djpr_plot_ui("vic_total_bop_cumul_line"),
     h2(br(), "Goods"),
     djpr_plot_ui("goods_bop_bar_chart",
       interactive = FALSE

--- a/R/page_bop.R
+++ b/R/page_bop.R
@@ -6,17 +6,15 @@ page_bop <- function(...) {
     yearly, over a particular period.  It shows the sum of the transactions of those involving
     goods or services."),
     h2(br(), "Goods and Services"),
-    djpr_plot_ui("good_services_export_chart"),
+    djpr_plot_ui("good_services_import_chart"),
     br(),
     djpr_plot_ui("total_bop_bar_chart",
       interactive = FALSE
     ),
     br(),
-    djpr_plot_ui("good_services_import_chart"),
-    br(),
     djpr_plot_ui("goods_export_import_line"),
     br(),
-    djpr_plot_ui("Vic_total_bop_bar_chart",
+    djpr_plot_ui("vic_total_bop_cumul_line",
       interactive = FALSE
     ),
     h2(br(), "Goods"),
@@ -37,9 +35,6 @@ page_bop <- function(...) {
     djpr_plot_ui("NSW_Vic_Services_line_chart"),
     br(),
     h2(br(), "Balance of Trade "),
-    djpr_plot_ui("trade_balance_line_chart"),
-    br(),
-    centred_row(htmlOutput("bop_footnote")),
-    br()
+    djpr_plot_ui("trade_balance_line_chart")
   )
 }

--- a/R/server.R
+++ b/R/server.R
@@ -197,7 +197,7 @@ server <- function(input, output, session) {
     height_percent = 75,
     plt_change = plt_change,
     date_slider = FALSE,
-    interactive = FALSE
+    interactive = TRUE
   )
   # Balance of Payments---
   # Goods:Goods imports and exports since COVID

--- a/R/server.R
+++ b/R/server.R
@@ -191,8 +191,8 @@ server <- function(input, output, session) {
     plt_change = plt_change
   )
   # Goods and Services: Export of goods and services for Victoria by calendar year
-  djpr_plot_server("Vic_total_bop_bar_chart",
-    viz_Vic_total_bop_bar_chart,
+  djpr_plot_server("vic_total_bop_cumul_line",
+    viz_vic_total_bop_cumul_line,
     data = bop,
     height_percent = 75,
     plt_change = plt_change,

--- a/R/viz_bop.R
+++ b/R/viz_bop.R
@@ -1084,7 +1084,7 @@ viz_vic_total_bop_cumul_line <- function(data = bop) {
       data = df %>%
         dplyr::mutate(tooltip = paste0(
                   format(.data$date, "%b %Y"), "\n",
-                  format(djprshiny::round2(.data$value, 1),big.mark=",")
+                  "$", format(djprshiny::round2(.data$value, 1),big.mark=","), "m"
                   ),
                   date = lubridate::ymd(paste0(2021,"-", lubridate::month(.data$date),"-", "01"))) %>%
         dplyr::group_by(year) %>%


### PR DESCRIPTION
Yearly comparison in bop chart did not account for differences in year length, new chart attempts to address this. Tooltips not yet working as intended, labelling error.