### PR TITLE
Truncating launchpad labels to improve readability

### DIFF
--- a/R/viz_launchpad.R
+++ b/R/viz_launchpad.R
@@ -68,9 +68,9 @@ viz_launchpad_chart <- function(data = merch,
     filter(country_dest %in% country,
          origin %in% region,
          sitc_code %in% top_5_code) %>%
-    select(sitc, date, value, sitc_code)%>%
-    group_by(sitc)%>%
-    mutate(sitc_shrink = strsplit(sitc, "[(]")[[1]][1])
+    select(sitc, date, value, sitc_code) %>%
+    group_by(sitc) %>%
+    mutate(sitc_shrink = paste0(sitc_code, ": ", stringr::str_trunc(sitc, 20, "right")))
 
   latest_month <- format(max(df$date), "%B %Y")
 


### PR DESCRIPTION
Address issue #41 by truncating labels so that they show the SITC code and a portion of the SITC name. 