### PR TITLE
Using curl for better linux compatability (tests)

### DIFF
--- a/R/read_merch.R
+++ b/R/read_merch.R
@@ -28,7 +28,7 @@ read_merch <- function(path = tempdir(),
   if (series == "export") {
     url <- "https://www.abs.gov.au/websitedbs/D3110132.nsf/home/DataExplorer/$File/MERCH_EXP.zip"
     exports_dest_zip <- file.path(path, basename(url))
-    download.file(url, exports_dest_zip, mode="wb")
+    download.file(url, exports_dest_zip, method = "curl", quiet = TRUE)
     utils::unzip(exports_dest_zip, exdir=path)
     exp_csv<- list.files(path, pattern="MERCH_EXP.csv",full.names=TRUE)
     merch <- data.table::fread(
@@ -83,7 +83,7 @@ read_merch <- function(path = tempdir(),
   if (series == "import") {
     url <- "https://www.abs.gov.au/websitedbs/D3110132.nsf/home/DataExplorer/$File/MERCH_IMP.zip"
     imports_dest_zip <- file.path(path, basename(url))
-    download.file(url, imports_dest_zip, mode="wb")
+    download.file(url, imports_dest_zip, method = "curl", quiet = TRUE)
     utils::unzip(imports_dest_zip, exdir=path)
     imp_csv<- list.files(path, pattern="MERCH_IMP.csv",full.names=TRUE)
     merch <- data.table::fread(


### PR DESCRIPTION
The download.file calls are falling over during automatic tests. Works just fine and passes tests on windows machines so I think it may be a ubuntu/linux issue. Trying curl downloads instead to see if that helps. 